### PR TITLE
Add exposed mutable livedata

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You may want to activate or deactivate rules according to your project needs.
 android-rules:
   TestNameShouldFollowNamingConvention:
     active: true
-    namingConvention: 'backtick' // backtick, snake_case or camelCase
+    namingConvention: 'backtick' // REQUIRED: backtick, snake_case or camelCase
   ViewModelExposesState:
     active: true
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,71 @@ This repository contains an opinionated set of Detekt Rules for Android projects
 
 ## Detekt Rules
 
-| Rule | Description | Configuration options | 
-| --- | --- | --- |
-| **TestNameShouldFollowNamingConvention** | Checks whether test names follow the name convention | [backtick, snake_case, camelCase] |
+
+### TestNameShouldFollowNamingConvention
+
+Checks whether test names follow the name convention. This rule only applies if method is annotated with `@Test`
+
+#### Config options
+
+```yml
+android-rules:
+  TestNameShouldFollowNamingConvention:
+    active: true
+    namingConvention: 'backtick' // backtick, snake_case or camelCase
+```
+
+#### NON-compliant code
+
+CONFIG: backtick
+```kotlin
+@Test
+fun additionIsCorrect(){
+    // ...
+}
+```
+#### Compliant code
+
+**CONFIG: backtick*
+```kotlin
+@Test
+fun `addition is correct`(){
+    // ...
+}
+```
+
+**CONFIG: snake_case**
+```kotlin
+@Test
+fun addition_is_correct(){
+    // ...
+}
+```
+
+**CONFIG: camelCase**
+```kotlin
+@Test
+fun additionIsCorrect(){
+    // ...
+}
+```
+
+### ViewModelExposesState
+
+MVVM has popularized the use of ViewModels in Android apps. Exposing a MutableLiveData to the View layer is an antipattern and should be avoided when using ViewModels.
+
+#### Non-compliant code
+
+```kotlin
+class LoginViewModel: ViewModel() {
+     val loginViewState = MutableLiveData<LoginViewState>()
+}
+```
+
+#### Compliant code
+```kotlin
+class LoginViewModel: ViewModel() {
+     private val loginViewState = MutableLiveData<LoginViewState>()
+     val loginViewState: LiveData<LoginViewState> = _loginViewState
+}
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,24 @@
 This repository contains an opinionated set of Detekt Rules for Android projects
 
 
-## Detekt Rules
+## Getting started
+
+#### Add this library declaration into your detekt dependencies
+
+```groovy
+detekt {
+    // ...
+}
+
+dependencies {
+    detektPlugins "br.com.wesjon:detekt-android-rules:0.1" // Add it here
+    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$detekt_version"
+}
+```
+
+#### Include a new block in your `detekt.yml` file
+
+You may want to activate or deactivate rules according to your project needs.
 
 ```yml
 android-rules:
@@ -31,7 +48,7 @@ fun additionIsCorrect(){
 ```
 #### Compliant code
 
-**CONFIG: backtick*
+**CONFIG: backtick**
 ```kotlin
 @Test
 fun `addition is correct`(){

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ android-rules:
     active: true
 ```
 
+## Rules
+
 ### TestNameShouldFollowNamingConvention
 
 Checks whether test names follow the name convention. This rule only applies if method is annotated with `@Test`

--- a/README.md
+++ b/README.md
@@ -7,19 +7,18 @@ This repository contains an opinionated set of Detekt Rules for Android projects
 
 ## Detekt Rules
 
-
-### TestNameShouldFollowNamingConvention
-
-Checks whether test names follow the name convention. This rule only applies if method is annotated with `@Test`
-
-#### Config options
-
 ```yml
 android-rules:
   TestNameShouldFollowNamingConvention:
     active: true
     namingConvention: 'backtick' // backtick, snake_case or camelCase
+  ViewModelExposesState:
+    active: true
 ```
+
+### TestNameShouldFollowNamingConvention
+
+Checks whether test names follow the name convention. This rule only applies if method is annotated with `@Test`
 
 #### NON-compliant code
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains an opinionated set of Detekt Rules for Android projects
 
 ## Getting started
 
-#### Add this library declaration into your detekt dependencies
+#### 1. Add this library declaration into your detekt dependencies
 
 ```groovy
 detekt {
@@ -20,7 +20,7 @@ dependencies {
 }
 ```
 
-#### Include a new block in your `detekt.yml` file
+#### 2. Include a new block in your `detekt.yml` file
 
 You may want to activate or deactivate rules according to your project needs.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ android-rules:
     namingConvention: 'backtick' // REQUIRED: backtick, snake_case or camelCase
   ViewModelExposesState:
     active: true
+    customViewModel: 'BaseViewModel' // OPTIONAL: If your application uses a base/custom ViewModel
 ```
 
 ## Rules

--- a/android-rules/build.gradle
+++ b/android-rules/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "kotlin"
+apply plugin: 'maven-publish'
 
 dependencies {
     compileOnly "io.gitlab.arturbosch.detekt:detekt-api:$detekt_version"
@@ -7,6 +8,20 @@ dependencies {
     testImplementation "com.google.truth:truth:1.1.2"
     testImplementation "io.gitlab.arturbosch.detekt:detekt-api:$detekt_version"
     testImplementation "io.gitlab.arturbosch.detekt:detekt-test:$detekt_version"
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            core(MavenPublication) {
+                from components.java
+
+                artifactId = 'detekt-rules-android'
+                groupId = "br.com.wesjon"
+                version = "0.1"
+            }
+        }
+    }
 }
 
 compileKotlin {

--- a/android-rules/src/main/kotlin/br/com/wesjon/detekt/AndroidDetektRulesProvider.kt
+++ b/android-rules/src/main/kotlin/br/com/wesjon/detekt/AndroidDetektRulesProvider.kt
@@ -1,6 +1,7 @@
 package br.com.wesjon.detekt
 
 import br.com.wesjon.detekt.rule.TestNameShouldFollowNamingConvention
+import br.com.wesjon.detekt.rule.ViewModelExposesState
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -9,6 +10,9 @@ class AndroidDetektRulesProvider : RuleSetProvider {
     override val ruleSetId: String = "android-rules"
 
     override fun instance(config: Config) = RuleSet(
-        ruleSetId, listOf(TestNameShouldFollowNamingConvention(config))
+        ruleSetId, listOf(
+            TestNameShouldFollowNamingConvention(config),
+            ViewModelExposesState(config)
+        )
     )
 }

--- a/android-rules/src/main/kotlin/br/com/wesjon/detekt/Tokens.kt
+++ b/android-rules/src/main/kotlin/br/com/wesjon/detekt/Tokens.kt
@@ -2,4 +2,5 @@ package br.com.wesjon.detekt
 
 object Tokens {
     const val TEST_ANNOTATION = "@Test"
+    const val VIEW_MODEL_NAME = "ViewModel"
 }

--- a/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/NoLoopInTestRule.kt
+++ b/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/NoLoopInTestRule.kt
@@ -1,5 +1,6 @@
 package br.com.wesjon.detekt.rule
 
+import br.com.wesjon.detekt.util.isTestFunction
 import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.psi.KtLoopExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -16,14 +17,9 @@ class NoLoopInTestRule : Rule() {
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)
 
-        val isTestMethod = function.annotationEntries.any {
-            it.text == "@Test"
-        }
-
-        if (isTestMethod) {
+        if (function.isTestFunction()) {
             val containsLoop =
-                function.bodyExpression
-                    ?.anyDescendantOfType<KtLoopExpression>() ?: false
+                function.bodyExpression?.anyDescendantOfType<KtLoopExpression>() ?: false
             if (containsLoop) {
                 report(
                     CodeSmell(

--- a/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/TestNameShouldFollowNamingConvention.kt
+++ b/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/TestNameShouldFollowNamingConvention.kt
@@ -28,8 +28,6 @@ enum class NamingConventions(
     );
 
     companion object {
-        val options = values().map { it.identifier }
-
         fun getNamingConventionByIdentifier(identifier: String) =
             values().find { it.identifier == identifier }
     }
@@ -70,6 +68,7 @@ class TestNameShouldFollowNamingConvention(config: Config) : Rule(config) {
 
     companion object {
         const val CONVENTION_KEY = "namingConvention"
-        private val optionsText = "options: ${NamingConventions.options.joinToString()}"
+        private val optionsText =
+            "options: ${NamingConventions.values().joinToString { it.identifier }}"
     }
 }

--- a/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/TestNameShouldFollowNamingConvention.kt
+++ b/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/TestNameShouldFollowNamingConvention.kt
@@ -40,7 +40,7 @@ class TestNameShouldFollowNamingConvention(config: Config) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    private val selectedNamingConvention = valueOrDefault(CONVENTION_KEY, "")
+    private val selectedNamingConvention = valueOrDefault(KEY_CONVENTION, "")
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)
@@ -67,7 +67,7 @@ class TestNameShouldFollowNamingConvention(config: Config) : Rule(config) {
     }
 
     companion object {
-        const val CONVENTION_KEY = "namingConvention"
+        const val KEY_CONVENTION = "namingConvention"
         private val optionsText =
             "options: ${NamingConventions.values().joinToString { it.identifier }}"
     }

--- a/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/TestNameShouldFollowNamingConvention.kt
+++ b/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/TestNameShouldFollowNamingConvention.kt
@@ -68,7 +68,6 @@ class TestNameShouldFollowNamingConvention(config: Config) : Rule(config) {
         }
     }
 
-
     companion object {
         const val CONVENTION_KEY = "namingConvention"
         private val optionsText = "options: ${NamingConventions.options.joinToString()}"

--- a/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesState.kt
+++ b/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesState.kt
@@ -17,8 +17,9 @@ class ViewModelExposesState(config: Config) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    private val customBaseViewModels =
-        ruleSetConfig.valueOrDefaultCommaSeparated(KEY_CUSTOM_VIEWMODEL_CLASSES_NAME, emptyList())
+    private val customBaseViewModels = ruleSetConfig
+        .subConfig(issue.id)
+        .valueOrDefaultCommaSeparated(KEY_CUSTOM_VIEWMODEL_CLASSES_NAME, emptyList())
 
     override fun visitClass(klass: KtClass) {
         super.visitClass(klass)
@@ -44,7 +45,7 @@ class ViewModelExposesState(config: Config) : Rule(config) {
     }
 
     companion object {
-        val KEY_CUSTOM_VIEWMODEL_CLASSES_NAME = "customViewModels"
+        const val KEY_CUSTOM_VIEWMODEL_CLASSES_NAME = "customViewModels"
         private val mutableStateTypes = listOf("MutableLiveData", "MutableStateFlow")
     }
 }

--- a/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesState.kt
+++ b/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesState.kt
@@ -1,0 +1,40 @@
+package br.com.wesjon.detekt.rule
+
+import br.com.wesjon.detekt.Tokens
+import br.com.wesjon.detekt.util.isViewModel
+import br.com.wesjon.detekt.util.typeName
+import io.gitlab.arturbosch.detekt.api.*
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.psiUtil.containingClass
+import org.jetbrains.kotlin.psi.psiUtil.isPublic
+
+class ViewModelExposesState(config: Config) : Rule(config) {
+    override val issue = Issue(
+        id = javaClass.simpleName,
+        severity = Severity.Maintainability,
+        description = "The ViewModel is exposing a mutable state that might be changed by other layers",
+        Debt.TWENTY_MINS
+    )
+
+    override fun visitProperty(property: KtProperty) {
+        super.visitProperty(property)
+
+        if (property.isPublic && property.containingClass().isViewModel()) {
+            val isMutableStateProperty = property.typeName in mutableStateTypes
+            if (isMutableStateProperty) {
+                val viewModelName = property.containingClass()?.name ?: Tokens.VIEW_MODEL_NAME
+                report(
+                    CodeSmell(
+                        issue,
+                        Entity.from(property),
+                        "Property ${property.name} exposes the $viewModelName state"
+                    )
+                )
+            }
+        }
+    }
+
+    companion object {
+        private val mutableStateTypes = listOf("MutableLiveData", "MutableStateFlow")
+    }
+}

--- a/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesState.kt
+++ b/android-rules/src/main/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesState.kt
@@ -3,6 +3,7 @@ package br.com.wesjon.detekt.rule
 import br.com.wesjon.detekt.util.isViewModel
 import br.com.wesjon.detekt.util.typeName
 import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
@@ -16,10 +17,13 @@ class ViewModelExposesState(config: Config) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
+    private val customBaseViewModels =
+        ruleSetConfig.valueOrDefaultCommaSeparated(KEY_CUSTOM_VIEWMODEL_CLASSES_NAME, emptyList())
+
     override fun visitClass(klass: KtClass) {
         super.visitClass(klass)
 
-        if (klass.isViewModel()) {
+        if (klass.isViewModel(*customBaseViewModels.toTypedArray())) {
             val mutableStateProperties = klass.collectDescendantsOfType<KtProperty>()
                 .asSequence()
                 .filter { property -> property.isPublic }
@@ -40,6 +44,7 @@ class ViewModelExposesState(config: Config) : Rule(config) {
     }
 
     companion object {
+        val KEY_CUSTOM_VIEWMODEL_CLASSES_NAME = "customViewModels"
         private val mutableStateTypes = listOf("MutableLiveData", "MutableStateFlow")
     }
 }

--- a/android-rules/src/main/kotlin/br/com/wesjon/detekt/util/FunctionExtensions.kt
+++ b/android-rules/src/main/kotlin/br/com/wesjon/detekt/util/FunctionExtensions.kt
@@ -1,6 +1,31 @@
 package br.com.wesjon.detekt.util
 
 import br.com.wesjon.detekt.Tokens
-import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
+
+val KtProperty?.typeName: String?
+    get() {
+        val referencedName = (this?.typeReference?.typeElement as? KtUserType)?.referencedName
+        return if (referencedName != null) {
+            referencedName
+        } else {
+            (this?.initializer as KtCallExpression).referenceExpression()?.text
+        }
+    }
 
 fun KtNamedFunction.isTestFunction() = annotationEntries.any { it.text == Tokens.TEST_ANNOTATION }
+
+fun KtClass?.isViewModel(vararg viewModelAlternativeNames: String): Boolean {
+    val instance = this
+
+    return if (instance == null) {
+        false
+    } else {
+        val inheritsViewModel = instance.superTypeListEntries.any { superClass ->
+            val superClassName = superClass.typeReference?.text
+            superClassName == Tokens.VIEW_MODEL_NAME || superClassName in viewModelAlternativeNames
+        }
+        inheritsViewModel
+    }
+}

--- a/android-rules/src/test/kotlin/br/com/wesjon/detekt/rule/TestNameShouldFollowNamingConventionTest.kt
+++ b/android-rules/src/test/kotlin/br/com/wesjon/detekt/rule/TestNameShouldFollowNamingConventionTest.kt
@@ -1,6 +1,6 @@
 package br.com.wesjon.detekt.rule
 
-import br.com.wesjon.detekt.rule.TestNameShouldFollowNamingConvention.Companion.CONVENTION_KEY
+import br.com.wesjon.detekt.rule.TestNameShouldFollowNamingConvention.Companion.KEY_CONVENTION
 import com.google.common.truth.Truth.assertThat
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
@@ -8,13 +8,13 @@ import org.junit.Test
 
 class TestNameShouldFollowNamingConventionTest {
     private val testConventionBacktick = TestNameShouldFollowNamingConvention(
-        TestConfig(mapOf(CONVENTION_KEY to NamingConventions.BACKTICK.identifier))
+        TestConfig(mapOf(KEY_CONVENTION to NamingConventions.BACKTICK.identifier))
     )
     private val testConventionSnakeCase = TestNameShouldFollowNamingConvention(
-        TestConfig(mapOf(CONVENTION_KEY to NamingConventions.SNAKE_CASE.identifier))
+        TestConfig(mapOf(KEY_CONVENTION to NamingConventions.SNAKE_CASE.identifier))
     )
     private val testConventionCammelCase = TestNameShouldFollowNamingConvention(
-        TestConfig(mapOf(CONVENTION_KEY to NamingConventions.CAMEL_CASE.identifier))
+        TestConfig(mapOf(KEY_CONVENTION to NamingConventions.CAMEL_CASE.identifier))
     )
 
     @Test
@@ -110,7 +110,7 @@ class TestNameShouldFollowNamingConventionTest {
     @Test(expected = IllegalArgumentException::class)
     fun `rule config contains invalid namingConvention throw exception`() {
         TestNameShouldFollowNamingConvention(
-            TestConfig(mapOf(CONVENTION_KEY to "invalid"))
+            TestConfig(mapOf(KEY_CONVENTION to "invalid"))
         ).lint("@Test fun test(){}")
     }
 }

--- a/android-rules/src/test/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesStateTest.kt
+++ b/android-rules/src/test/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesStateTest.kt
@@ -1,7 +1,9 @@
 package br.com.wesjon.detekt.rule
 
+import br.com.wesjon.detekt.rule.ViewModelExposesState.Companion.KEY_CUSTOM_VIEWMODEL_CLASSES_NAME
 import com.google.common.truth.Truth.assertThat
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.Test
 
@@ -22,6 +24,29 @@ class ViewModelExposesStateTest {
             .isEqualTo("Property loginViewStateLiveData exposes the LoginViewModel state")
         assertThat(findings[1].message)
             .isEqualTo("Property loginViewStateStateFlow exposes the LoginViewModel state")
+    }
+
+    @Test
+    fun `CustomViewModel exposes mutablestate report issue`() {
+        val findings = ViewModelExposesState(
+            TestConfig(mapOf(KEY_CUSTOM_VIEWMODEL_CLASSES_NAME to "BaseViewModel,CustomViewModel"))
+        ).lint(
+            """
+                class LoginViewModel: BaseViewModel() {
+                     val loginViewStateLiveData = MutableLiveData<LoginViewState>()
+                }
+                
+                class LoginViewModel2: CustomViewModel() {
+                     val loginViewStateLiveData2 = MutableLiveData<LoginViewState>()
+                }
+                """.trimIndent()
+        )
+
+        assertThat(findings).hasSize(2)
+        assertThat(findings[0].message)
+            .isEqualTo("Property loginViewStateLiveData exposes the LoginViewModel state")
+        assertThat(findings[1].message)
+            .isEqualTo("Property loginViewStateLiveData2 exposes the LoginViewModel2 state")
     }
 
     @Test

--- a/android-rules/src/test/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesStateTest.kt
+++ b/android-rules/src/test/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesStateTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 class ViewModelExposesStateTest {
     @Test
     fun `ViewModel exposes mutablestate report issue`() {
-        val findings = ViewModelExposesState(Config.empty).lint(
+    val findings = ViewModelExposesState(Config.empty).lint(
             """
                 class LoginViewModel: ViewModel() {
                      val loginViewStateLiveData = MutableLiveData<LoginViewState>()

--- a/android-rules/src/test/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesStateTest.kt
+++ b/android-rules/src/test/kotlin/br/com/wesjon/detekt/rule/ViewModelExposesStateTest.kt
@@ -1,0 +1,40 @@
+package br.com.wesjon.detekt.rule
+
+import com.google.common.truth.Truth.assertThat
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.lint
+import org.junit.Test
+
+class ViewModelExposesStateTest {
+    @Test
+    fun `ViewModel exposes mutablestate report issue`() {
+        val findings = ViewModelExposesState(Config.empty).lint(
+            """
+                class LoginViewModel: ViewModel() {
+                     val loginViewStateLiveData = MutableLiveData<LoginViewState>()
+                     val loginViewStateStateFlow = MutableStateFlow<LoginViewState>()
+                }
+                """.trimIndent()
+        )
+
+        assertThat(findings).hasSize(2)
+        assertThat(findings[0].message)
+            .isEqualTo("Property loginViewStateLiveData exposes the LoginViewModel state")
+        assertThat(findings[1].message)
+            .isEqualTo("Property loginViewStateStateFlow exposes the LoginViewModel state")
+    }
+
+    @Test
+    fun `ViewModel doesnt expose mutable state report no issue`() {
+        val findings = ViewModelExposesState(Config.empty).lint(
+            """
+                class LoginViewModel: ViewModel() {
+                     private val loginViewState = MutableLiveData<LoginViewState>()
+                     val loginViewState: LiveData<LoginViewState> = _loginViewState
+                }
+                """.trimIndent()
+        )
+
+        assertThat(findings).isEmpty()
+    }
+}

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -10,7 +10,7 @@ build:
 config:
   validation: true
   # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
-  excludes: ''
+  excludes: 'android-rules'
 
 processors:
   active: true
@@ -650,3 +650,6 @@ android-rules:
   TestNameShouldFollowNamingConvention:
     active: true
     namingConvention: 'backtick'
+  ViewModelExposesState:
+    active: true
+    customViewModels: 'BaseViewModel,CustomViewModel'

--- a/sample/src/main/java/br/com/wesjon/MainActivity.kt
+++ b/sample/src/main/java/br/com/wesjon/MainActivity.kt
@@ -3,3 +3,12 @@ package br.com.wesjon
 import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity(R.layout.activity_main)
+
+open class ViewModel
+open class BaseViewModel
+open class CustomViewModel
+open class MutableLiveData
+
+class LoginViewModel: CustomViewModel(){
+    val loginState = MutableLiveData()
+}


### PR DESCRIPTION
## Description

MVVM has popularized the use of ViewModels in Android apps. Exposing a MutableLiveData to the View layer is an antipattern and should be avoided when using ViewModels. This rule detect scenarios where a LiveData or StateFlow is exposed as mutable.

## Non-compliant code

```kotlin
class LoginViewModel: ViewModel() {
     val loginViewState = MutableLiveData<LoginViewState>()
}
```

## Compliant code
```kotlin
class LoginViewModel: ViewModel() {
     private val loginViewState = MutableLiveData<LoginViewState>()
     val loginViewState: LiveData<LoginViewState> = _loginViewState
}
```

Fix #29 